### PR TITLE
build: use a branch of gomod2nix that supports go 1.23

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -86,11 +86,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724232775,
-        "narHash": "sha256-6u2DycIEgrgNYlLxyGqdFVmBNiKIitnQKJ1pbRP5oko=",
+        "lastModified": 1726520618,
+        "narHash": "sha256-jOsaBmJ/EtX5t/vbylCdS7pWYcKGmWOKg4QKUzKr6dA=",
         "owner": "cachix",
         "repo": "cachix",
-        "rev": "03b6cb3f953097bff378fb8b9ea094bd091a4ec7",
+        "rev": "695525f9086542dfb09fde0871dbf4174abbf634",
         "type": "github"
       },
       "original": {
@@ -149,11 +149,11 @@
         "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
-        "lastModified": 1728740426,
-        "narHash": "sha256-Y7bHzOlhA3jSG0zewmrAxFeeiRIK6aASlMyW6IjB0ws=",
+        "lastModified": 1730846267,
+        "narHash": "sha256-V1JR87wGG8g7bXYo81ueE3MhUt9KXmTXjam+Lkb6cvc=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "ef61728d91ad5eb91f86cdbcc16070602e7afa16",
+        "rev": "b6b5b96bd0b669b1f41147cbde950c26085a25c8",
         "type": "github"
       },
       "original": {
@@ -243,11 +243,11 @@
         "pre-commit-hooks": "pre-commit-hooks_4"
       },
       "locked": {
-        "lastModified": 1726826452,
-        "narHash": "sha256-bzlp1BmyG+lyc3BvjHLVarck0XVj251R/ZAidtSsEzg=",
+        "lastModified": 1730412360,
+        "narHash": "sha256-gPXX25FQL5nhBgIn4nChyJzdXEa+hEyzJ7kITVDsqVM=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "2bdf6461e88c7e93b94d72d8b11d5a61f167cbf5",
+        "rev": "45847cb1f14a6d8cfa86ea943703c54a8798ae7e",
         "type": "github"
       },
       "original": {
@@ -339,11 +339,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726873115,
-        "narHash": "sha256-8tHdxcNKetrsBtUDVkO5q/ZrilhVNU3lH7PNMq7xnos=",
+        "lastModified": 1730832712,
+        "narHash": "sha256-brT4D33pAaPt4n0j39cIafoJBLiW3mA9HuFaoi623kA=",
         "owner": "jtrrll",
         "repo": "env-help",
-        "rev": "491276f1a67b516949092b2944271e6a6c953f62",
+        "rev": "b4c35c1acb256ce9c9c2783a7496b9f5b783f03f",
         "type": "github"
       },
       "original": {
@@ -466,11 +466,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1726153070,
-        "narHash": "sha256-HO4zgY0ekfwO5bX0QH/3kJ/h4KvUDFZg8YpkNwIbg1U=",
+        "lastModified": 1727826117,
+        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a",
+        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
         "type": "github"
       },
       "original": {
@@ -484,11 +484,11 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1727826117,
-        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
+        "lastModified": 1730504689,
+        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
+        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
         "type": "github"
       },
       "original": {
@@ -634,15 +634,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1728509152,
-        "narHash": "sha256-tQo1rg3TlwgyI8eHnLvZSlQx9d/o2Rb4oF16TfaTOw0=",
-        "owner": "nix-community",
+        "lastModified": 1725226629,
+        "narHash": "sha256-0l5gtNAf3408INFPbvbMvHghd44LgKhMuqUcY6vH5N8=",
+        "owner": "obreitwi",
         "repo": "gomod2nix",
-        "rev": "d5547e530464c562324f171006fc8f639aa01c9f",
+        "rev": "983228366edc1bed1be6e6f7a45e285b4707b9ba",
         "type": "github"
       },
       "original": {
-        "owner": "nix-community",
+        "owner": "obreitwi",
+        "ref": "fix/go_mod_vendor",
         "repo": "gomod2nix",
         "type": "github"
       }
@@ -896,11 +897,11 @@
         "pre-commit-hooks": "pre-commit-hooks_3"
       },
       "locked": {
-        "lastModified": 1725980365,
-        "narHash": "sha256-uDwWyizzlQ0HFzrhP6rVp2+2NNA+/TM5zT32dR8GUlg=",
+        "lastModified": 1727438425,
+        "narHash": "sha256-X8ES7I1cfNhR9oKp06F6ir4Np70WGZU5sfCOuNBEwMg=",
         "owner": "domenkozar",
         "repo": "nix",
-        "rev": "1e61e9f40673f84c3b02573145492d8af581bec5",
+        "rev": "f6c5ae4c1b2e411e6b1e6a8181cc84363d6a7546",
         "type": "github"
       },
       "original": {
@@ -960,18 +961,6 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1725233747,
-        "narHash": "sha256-Ss8QWLXdr2JCBPcYChJhz4xJm+h/xjl4G0c0XlP6a74=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
-      }
-    },
-    "nixpkgs-lib_2": {
-      "locked": {
         "lastModified": 1727825735,
         "narHash": "sha256-0xHYkMkeLVQAMa7gvkddbPqpxph+hDzdu1XdGPJR+Os=",
         "type": "tarball",
@@ -980,6 +969,18 @@
       "original": {
         "type": "tarball",
         "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
+      }
+    },
+    "nixpkgs-lib_2": {
+      "locked": {
+        "lastModified": 1730504152,
+        "narHash": "sha256-lXvH/vOfb4aGYyvFmZK/HlsNsr/0CVWlwYvo2rxJk3s=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
       }
     },
     "nixpkgs-regression": {
@@ -1160,11 +1161,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1728538411,
-        "narHash": "sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU=",
+        "lastModified": 1730768919,
+        "narHash": "sha256-8AKquNnnSaJRXZxc5YmF/WfmxiHX6MMZZasRP6RRQkE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221",
+        "rev": "a04d33c0c3f1a59a2c1cb0c6e34cd24500e5a1dc",
         "type": "github"
       },
       "original": {
@@ -1348,11 +1349,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1725513492,
-        "narHash": "sha256-tyMUA6NgJSvvQuzB7A1Sf8+0XCHyfSPRx/b00o6K0uo=",
+        "lastModified": 1726745158,
+        "narHash": "sha256-D5AegvGoEjt4rkKedmxlSEmC+nNLMBPWFxvmYnVLhjk=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "7570de7b9b504cfe92025dd1be797bf546f66528",
+        "rev": "4e743a6920eab45e8ba0fbe49dc459f1423a4b74",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,9 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     gomod2nix = {
       inputs.nixpkgs.follows = "nixpkgs";
-      url = "github:nix-community/gomod2nix";
+      # Uses a fork of "github:nix-community/gomod2nix" that generates vendor/modules.txt,
+      # and therefore supports Go 1.23.
+      url = "github:obreitwi/gomod2nix/fix/go_mod_vendor";
     };
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   };

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -1,9 +1,22 @@
-schema = 3
+schema = 4
+vendorModulesTxt = "# github.com/aymanbagabas/go-osc52/v2 v2.0.1\n## explicit; go 1.16\ngithub.com/aymanbagabas/go-osc52/v2\n# github.com/charmbracelet/lipgloss v1.0.0\n## explicit; go 1.18\ngithub.com/charmbracelet/lipgloss\n# github.com/charmbracelet/log v0.4.0\n## explicit; go 1.19\ngithub.com/charmbracelet/log\n# github.com/charmbracelet/x/ansi v0.4.2\n## explicit; go 1.18\ngithub.com/charmbracelet/x/ansi\ngithub.com/charmbracelet/x/ansi/parser\n# github.com/cyphar/filepath-securejoin v0.2.5\n## explicit; go 1.13\ngithub.com/cyphar/filepath-securejoin\n# github.com/davecgh/go-spew v1.1.1\n## explicit\ngithub.com/davecgh/go-spew/spew\n# github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376\n## explicit; go 1.13\ngithub.com/go-git/gcfg\ngithub.com/go-git/gcfg/scanner\ngithub.com/go-git/gcfg/token\ngithub.com/go-git/gcfg/types\n# github.com/go-git/go-billy/v5 v5.6.0\n## explicit; go 1.20\ngithub.com/go-git/go-billy/v5\ngithub.com/go-git/go-billy/v5/helper/chroot\ngithub.com/go-git/go-billy/v5/helper/polyfill\ngithub.com/go-git/go-billy/v5/memfs\ngithub.com/go-git/go-billy/v5/osfs\ngithub.com/go-git/go-billy/v5/util\n# github.com/go-git/go-git/v5 v5.12.0\n## explicit; go 1.19\ngithub.com/go-git/go-git/v5/internal/path_util\ngithub.com/go-git/go-git/v5/plumbing/format/config\ngithub.com/go-git/go-git/v5/plumbing/format/gitignore\ngithub.com/go-git/go-git/v5/utils/ioutil\n# github.com/go-logfmt/logfmt v0.6.0\n## explicit; go 1.17\ngithub.com/go-logfmt/logfmt\n# github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99\n## explicit\ngithub.com/jbenet/go-context/io\n# github.com/lucasb-eyer/go-colorful v1.2.0\n## explicit; go 1.12\ngithub.com/lucasb-eyer/go-colorful\n# github.com/mattn/go-isatty v0.0.20\n## explicit; go 1.15\ngithub.com/mattn/go-isatty\n# github.com/mattn/go-runewidth v0.0.15\n## explicit; go 1.9\ngithub.com/mattn/go-runewidth\n# github.com/muesli/termenv v0.15.2\n## explicit; go 1.17\ngithub.com/muesli/termenv\n# github.com/pmezard/go-difflib v1.0.0\n## explicit\ngithub.com/pmezard/go-difflib/difflib\n# github.com/rivo/uniseg v0.4.7\n## explicit; go 1.18\ngithub.com/rivo/uniseg\n# github.com/stretchr/testify v1.9.0\n## explicit; go 1.17\ngithub.com/stretchr/testify/assert\ngithub.com/stretchr/testify/require\n# golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56\n## explicit; go 1.20\ngolang.org/x/exp/constraints\ngolang.org/x/exp/slices\ngolang.org/x/exp/slog\ngolang.org/x/exp/slog/internal\ngolang.org/x/exp/slog/internal/buffer\n# golang.org/x/net v0.27.0\n## explicit; go 1.18\ngolang.org/x/net/context\n# golang.org/x/sys v0.24.0\n## explicit; go 1.18\ngolang.org/x/sys/unix\ngolang.org/x/sys/windows\n# gopkg.in/warnings.v0 v0.1.2\n## explicit\ngopkg.in/warnings.v0\n# gopkg.in/yaml.v3 v3.0.1\n## explicit\ngopkg.in/yaml.v3\n"
 
 [mod]
+  [mod."github.com/aymanbagabas/go-osc52/v2"]
+    version = "v2.0.1"
+    hash = "sha256-6Bp0jBZ6npvsYcKZGHHIUSVSTAMEyieweAX2YAKDjjg="
+  [mod."github.com/charmbracelet/lipgloss"]
+    version = "v1.0.0"
+    hash = "sha256-6ilMmaNrkVUt+RtuDu2lMAGFWe6Dx6921swURY+M1HE="
+  [mod."github.com/charmbracelet/log"]
+    version = "v0.4.0"
+    hash = "sha256-VQerB44vC646n3fe3haJ3DHa9L5+GRhCfDfm1p3QnZk="
+  [mod."github.com/charmbracelet/x/ansi"]
+    version = "v0.4.2"
+    hash = "sha256-8MXyqHnzwGjl7z8ll8Tb5RQyj3ZhyK98ottgxRiBWjg="
   [mod."github.com/cyphar/filepath-securejoin"]
-    version = "v0.2.4"
-    hash = "sha256-heCD0xMxlwnHCHcRBgTjVexHOLyWI2zRW3E8NFKoLzk="
+    version = "v0.2.5"
+    hash = "sha256-Hb9fRUHnMJJwy7XuHRG2l0YiTKh/5jUz2YJVdYScIfE="
   [mod."github.com/davecgh/go-spew"]
     version = "v1.1.1"
     hash = "sha256-nhzSUrE1fCkN0+RL04N4h8jWmRFPPPWbCuDc7Ss0akI="
@@ -11,26 +24,47 @@ schema = 3
     version = "v1.5.1-0.20230307220236-3a3c6141e376"
     hash = "sha256-f4k0gSYuo0/q3WOoTxl2eFaj7WZpdz29ih6CKc8Ude8="
   [mod."github.com/go-git/go-billy/v5"]
-    version = "v5.5.0"
-    hash = "sha256-4XUoD2bOCMCdu83egb/y8kY/Fm0s1rWgPMtiahh38OQ="
+    version = "v5.6.0"
+    hash = "sha256-Hw+odNozpiixXqmsbahihdV+TBxpusm6/hDLngf7kUg="
   [mod."github.com/go-git/go-git/v5"]
     version = "v5.12.0"
     hash = "sha256-mD8EWOQ25FtKBWVSQhQ8V1Rr0tC/ySFZQ9GMDLRqwQU="
+  [mod."github.com/go-logfmt/logfmt"]
+    version = "v0.6.0"
+    hash = "sha256-RtIG2qARd5sT10WQ7F3LR8YJhS8exs+KiuUiVf75bWg="
   [mod."github.com/jbenet/go-context"]
     version = "v0.0.0-20150711004518-d14ea06fba99"
     hash = "sha256-VANNCWNNpARH/ILQV9sCQsBWgyL2iFT+4AHZREpxIWE="
+  [mod."github.com/lucasb-eyer/go-colorful"]
+    version = "v1.2.0"
+    hash = "sha256-Gg9dDJFCTaHrKHRR1SrJgZ8fWieJkybljybkI9x0gyE="
+  [mod."github.com/mattn/go-isatty"]
+    version = "v0.0.20"
+    hash = "sha256-qhw9hWtU5wnyFyuMbKx+7RB8ckQaFQ8D+8GKPkN3HHQ="
+  [mod."github.com/mattn/go-runewidth"]
+    version = "v0.0.15"
+    hash = "sha256-WP39EU2UrQbByYfnwrkBDoKN7xzXsBssDq3pNryBGm0="
+  [mod."github.com/muesli/termenv"]
+    version = "v0.15.2"
+    hash = "sha256-Eum/SpyytcNIchANPkG4bYGBgcezLgej7j/+6IhqoMU="
   [mod."github.com/pmezard/go-difflib"]
     version = "v1.0.0"
     hash = "sha256-/FtmHnaGjdvEIKAJtrUfEhV7EVo5A/eYrtdnUkuxLDA="
+  [mod."github.com/rivo/uniseg"]
+    version = "v0.4.7"
+    hash = "sha256-rDcdNYH6ZD8KouyyiZCUEy8JrjOQoAkxHBhugrfHjFo="
   [mod."github.com/stretchr/testify"]
     version = "v1.9.0"
     hash = "sha256-uUp/On+1nK+lARkTVtb5RxlW15zxtw2kaAFuIASA+J0="
+  [mod."golang.org/x/exp"]
+    version = "v0.0.0-20240719175910-8a7402abbf56"
+    hash = "sha256-mHEPy0vbd/pFwq5ZAEKaehCeYVQLEFDGnXAoVgkCLPo="
   [mod."golang.org/x/net"]
-    version = "v0.22.0"
-    hash = "sha256-pcefO4noO9I6mATKBWF6shgIjZvFg0kDsV1Jo/NsFns="
+    version = "v0.27.0"
+    hash = "sha256-GrlN5isYeEVrPZVAHK0MDQatttbnyfSPoWJHj0xqhjk="
   [mod."golang.org/x/sys"]
-    version = "v0.18.0"
-    hash = "sha256-bIFhfFp7Sj0E1gcE3X3l/jecCfSRLgrkb8f0Yr6tVR0="
+    version = "v0.24.0"
+    hash = "sha256-P0fsA+qy9taYHWPTtCs5XmrJ1i8tWfvkno+PNuc2elw="
   [mod."gopkg.in/warnings.v0"]
     version = "v0.1.2"
     hash = "sha256-ATVL9yEmgYbkJ1DkltDGRn/auGAjqGOfjQyBYyUo8s8="

--- a/internal/files/tree.go
+++ b/internal/files/tree.go
@@ -8,6 +8,7 @@ import (
 )
 
 // Iterates over a file tree, only producing paths that match the given matcher.
+// The iterator is guaranteed to yield parent directories before their children.
 func IterTree(fileSystem billy.Filesystem, match Matcher, p Path) iter.Seq2[Path, fs.FileInfo] {
 	return func(yield func(path Path, fileInfo fs.FileInfo) bool) {
 		// Process this path

--- a/internal/patterns/posix.go
+++ b/internal/patterns/posix.go
@@ -8,7 +8,9 @@ import (
 var (
 	// Matches a valid POSIX filename according to
 	// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_276.
-	validPosixFileName = regexp.MustCompile(`^[a-zA-Z0-9._][a-zA-Z0-9._\-]*$`)
+	// The length limitation is enforced by file systems rather than POSIX,
+	// but many file systems have a similar limit.
+	validPosixFileName = regexp.MustCompile(`^[a-zA-Z0-9._][a-zA-Z0-9._\-]{0,254}$`)
 
 	// Matches characters that are not valid in POSIX filenames according to
 	// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_276.


### PR DESCRIPTION
<!--
Before opening a pull request, please ensure you've done the following:

- 👷‍♀️ Created a small PR.
- 📝 Used a descriptive title.
- ✅ Provided tests for your changes (if applicable).
- 📗 Updated relevant documentation.

Please be patient! We will review your pull request as soon as possible.
-->

# Description
<!--
What does this change accomplish? Why did you make this change?
-->
The build was failing because `gomod2nix` currently does not support Go 1.23 because it does not generate `vendor/modules.txt`.
Replacing it with a fork that does support Go 1.23 fixed the build.

# Testing
<!--
How did you test your changes?
-->
Built locally

# Related Issues
<!--
For pull requests that close an issue, please include them below.
We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
Example: "Closes #10"
-->
None