### PR TITLE
ci: revert lint and test commands to headless commands

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,8 +36,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
-      - name: Lint
-        run: nix develop --impure -c lint
+      - name: Lint Nix code
+        run: nix develop --impure -c alejandra -c .
+      - name: Lint Go code
+        run: nix develop --impure -c golangci-lint run ./...
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -47,5 +49,5 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
       - name: Test
-        run: nix develop --impure -c unit
+        run: nix develop --impure -c go test ./...
 ...

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,10 +36,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
-      - name: Lint Nix code
-        run: nix develop --impure -c alejandra -c .
-      - name: Lint Go code
-        run: nix develop --impure -c golangci-lint run ./...
+      - name: Lint
+        run: nix develop --impure -c lint
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -49,5 +47,5 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
       - name: Test
-        run: nix develop --impure -c test
+        run: nix develop --impure -c unit
 ...

--- a/modules/devenv.nix
+++ b/modules/devenv.nix
@@ -82,13 +82,15 @@
           bench = {
             description = "Runs a specified benchmark test.";
             exec = ''
-              ${pkgs.gum}/bin/gum spin --show-output --spinner line --title "go test -bench" -- go test ./... -bench="$1"
+              ${pkgs.gum}/bin/gum spin --show-output --spinner line --title "go test -bench" -- \
+                go test ./... -bench="$1"
             '';
           };
           build = {
             description = "Builds the project binary.";
             exec = ''
-              ${pkgs.gum}/bin/gum spin --show-error --spinner line --title "gomod2nix" -- gomod2nix
+              ${pkgs.gum}/bin/gum spin --show-error --spinner line --title "gomod2nix" -- \
+                gomod2nix
               nix build .#snek-check
             '';
           };
@@ -101,30 +103,38 @@
           fuzz = {
             description = "Runs a specified fuzz test.";
             exec = ''
-              ${pkgs.gum}/bin/gum spin --show-output --spinner line --title "go test -fuzz" -- go test ./... -fuzz="$1"
+              ${pkgs.gum}/bin/gum spin --show-output --spinner line --title "go test -fuzz" -- \
+                go test ./... -fuzz="$1"
             '';
           };
           lint = {
             description = "Lints the project.";
             exec = ''
-              ${pkgs.gum}/bin/gum spin --show-error --spinner line --title "alejandra ." -- alejandra .
-              ${pkgs.gum}/bin/gum spin --show-error --spinner line --title "go mod tidy" -- go mod tidy
-              ${pkgs.gum}/bin/gum spin --show-error --spinner line --title "go fmt" -- go fmt ./...
-              ${pkgs.gum}/bin/gum spin --show-error --spinner line --title "go vet" -- go vet ./...
-              ${pkgs.gum}/bin/gum spin --show-error --spinner line --title "golangci-lint" -- golangci-lint run ./...
+              ${pkgs.gum}/bin/gum spin --show-error --spinner line --title "alejandra ." -- \
+                alejandra .
+              ${pkgs.gum}/bin/gum spin --show-error --spinner line --title "go mod tidy" -- \
+                go mod tidy
+              ${pkgs.gum}/bin/gum spin --show-error --spinner line --title "go fmt" -- \
+                go fmt ./...
+              ${pkgs.gum}/bin/gum spin --show-error --spinner line --title "go vet" -- \
+                go vet ./...
+              ${pkgs.gum}/bin/gum spin --show-error --spinner line --title "golangci-lint" -- \
+                golangci-lint run ./...
             '';
           };
           run = {
             description = "Runs the project.";
             exec = ''
-              ${pkgs.gum}/bin/gum spin --show-error --spinner line --title "gomod2nix" -- gomod2nix
+              ${pkgs.gum}/bin/gum spin --show-error --spinner line --title "gomod2nix" -- \
+                gomod2nix
               nix run .#snek -- "$@"
             '';
           };
           unit = {
             description = "Runs all unit tests.";
             exec = ''
-              ${pkgs.gum}/bin/gum spin --show-output --spinner line --title "go test" -- go test ./...
+              ${pkgs.gum}/bin/gum spin --show-output --spinner line --title "go test" -- \
+                go test ./...
             '';
           };
         };


### PR DESCRIPTION
<!--
Before opening a pull request, please ensure you've done the following:

- 👷‍♀️ Created a small PR.
- 📝 Used a descriptive title.
- ✅ Provided tests for your changes (if applicable).
- 📗 Updated relevant documentation.

Please be patient! We will review your pull request as soon as possible.
-->

# Description
<!--
What does this change accomplish? Why did you make this change?
-->
The commands used in CI by the lint and test jobs do not work without a graphical terminal. This change reverts those commands, while diverging slightly from the commands available in the development environment.

# Testing
<!--
How did you test your changes?
-->
N/A

# Related Issues
<!--
For pull requests that close an issue, please include them below.
We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
Example: "Closes #10"
-->
None